### PR TITLE
Retarget to .NET 4 and be able to build using msbuild

### DIFF
--- a/CSharpTranslator/src/Antlr.Runtime/Antlr3.Runtime.csproj
+++ b/CSharpTranslator/src/Antlr.Runtime/Antlr3.Runtime.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
     <ProjectType>Local</ProjectType>
@@ -8,7 +8,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <AssemblyKeyContainerName>
     </AssemblyKeyContainerName>
-    <AssemblyName>Antlr3-2.Runtime.DotNet20</AssemblyName>
+    <AssemblyName>Antlr3-2.Runtime</AssemblyName>
     <DefaultClientScript>JScript</DefaultClientScript>
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
@@ -23,7 +23,7 @@
     <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -77,7 +77,7 @@
     <ConfigurationOverrideFile>
     </ConfigurationOverrideFile>
     <DefineConstants>DOTNET2</DefineConstants>
-    <DocumentationFile>bin\Release\net-2.0\Antlr3-2.Runtime.DotNet20.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\net-2.0\Antlr3-2.Runtime.xml</DocumentationFile>
     <DebugSymbols>true</DebugSymbols>
     <FileAlignment>4096</FileAlignment>
     <RegisterForComInterop>false</RegisterForComInterop>

--- a/CSharpTranslator/src/CS2JTemplateGenerator/CS2JTemplateGenerator.csproj
+++ b/CSharpTranslator/src/CS2JTemplateGenerator/CS2JTemplateGenerator.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -14,24 +14,23 @@
     <FileAlignment>512</FileAlignment>
     <StartupObject>Twiglet.CS2J.Utility.TemplateFromDLL</StartupObject>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
-    <PlatformTarget>x86</PlatformTarget>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
-    <PlatformTarget>x86</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/CSharpTranslator/src/CS2JTemplateGenerator/CS2JTemplateGenerator.csproj
+++ b/CSharpTranslator/src/CS2JTemplateGenerator/CS2JTemplateGenerator.csproj
@@ -10,9 +10,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CS2JTemplateGenerator</RootNamespace>
     <AssemblyName>CS2JTemplateGenerator</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <StartupObject>Twiglet.CS2J.Utility.TemplateFromDLL</StartupObject>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -54,6 +55,9 @@
       <Project>{E6ACBB37-AF38-45E1-B399-0CEE63809A15}</Project>
       <Name>NDesk.Options</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/CSharpTranslator/src/CS2JTemplateGenerator/app.config
+++ b/CSharpTranslator/src/CS2JTemplateGenerator/app.config
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>

--- a/CSharpTranslator/src/CS2JTranslator.sln
+++ b/CSharpTranslator/src/CS2JTranslator.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NDesk.Options", "NDesk.Options\NDesk.Options.csproj", "{E6ACBB37-AF38-45E1-B399-0CEE63809A15}"
 EndProject
@@ -16,68 +16,29 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Debug|Mixed Platforms = Debug|Mixed Platforms
-		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
-		Release|Mixed Platforms = Release|Mixed Platforms
-		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{E6ACBB37-AF38-45E1-B399-0CEE63809A15}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E6ACBB37-AF38-45E1-B399-0CEE63809A15}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E6ACBB37-AF38-45E1-B399-0CEE63809A15}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{E6ACBB37-AF38-45E1-B399-0CEE63809A15}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{E6ACBB37-AF38-45E1-B399-0CEE63809A15}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{E6ACBB37-AF38-45E1-B399-0CEE63809A15}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E6ACBB37-AF38-45E1-B399-0CEE63809A15}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E6ACBB37-AF38-45E1-B399-0CEE63809A15}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{E6ACBB37-AF38-45E1-B399-0CEE63809A15}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{E6ACBB37-AF38-45E1-B399-0CEE63809A15}.Release|x86.ActiveCfg = Release|Any CPU
-		{39949CE9-8C9D-46C2-BE90-37FEE97CCBF9}.Debug|Any CPU.ActiveCfg = Debug|x86
-		{39949CE9-8C9D-46C2-BE90-37FEE97CCBF9}.Debug|Any CPU.Build.0 = Debug|x86
-		{39949CE9-8C9D-46C2-BE90-37FEE97CCBF9}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{39949CE9-8C9D-46C2-BE90-37FEE97CCBF9}.Debug|Mixed Platforms.Build.0 = Debug|x86
-		{39949CE9-8C9D-46C2-BE90-37FEE97CCBF9}.Debug|x86.ActiveCfg = Debug|x86
-		{39949CE9-8C9D-46C2-BE90-37FEE97CCBF9}.Debug|x86.Build.0 = Debug|x86
-		{39949CE9-8C9D-46C2-BE90-37FEE97CCBF9}.Release|Any CPU.ActiveCfg = Release|x86
-		{39949CE9-8C9D-46C2-BE90-37FEE97CCBF9}.Release|Any CPU.Build.0 = Release|x86
-		{39949CE9-8C9D-46C2-BE90-37FEE97CCBF9}.Release|Mixed Platforms.ActiveCfg = Release|x86
-		{39949CE9-8C9D-46C2-BE90-37FEE97CCBF9}.Release|Mixed Platforms.Build.0 = Release|x86
-		{39949CE9-8C9D-46C2-BE90-37FEE97CCBF9}.Release|x86.ActiveCfg = Release|x86
-		{39949CE9-8C9D-46C2-BE90-37FEE97CCBF9}.Release|x86.Build.0 = Release|x86
+		{39949CE9-8C9D-46C2-BE90-37FEE97CCBF9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{39949CE9-8C9D-46C2-BE90-37FEE97CCBF9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{39949CE9-8C9D-46C2-BE90-37FEE97CCBF9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{39949CE9-8C9D-46C2-BE90-37FEE97CCBF9}.Release|Any CPU.Build.0 = Release|Any CPU
 		{CF15D0D5-BE72-4F98-B70F-229ABA1DF0E8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{CF15D0D5-BE72-4F98-B70F-229ABA1DF0E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{CF15D0D5-BE72-4F98-B70F-229ABA1DF0E8}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{CF15D0D5-BE72-4F98-B70F-229ABA1DF0E8}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{CF15D0D5-BE72-4F98-B70F-229ABA1DF0E8}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{CF15D0D5-BE72-4F98-B70F-229ABA1DF0E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CF15D0D5-BE72-4F98-B70F-229ABA1DF0E8}.Release|Any CPU.Build.0 = Release|Any CPU
-		{CF15D0D5-BE72-4F98-B70F-229ABA1DF0E8}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{CF15D0D5-BE72-4F98-B70F-229ABA1DF0E8}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{CF15D0D5-BE72-4F98-B70F-229ABA1DF0E8}.Release|x86.ActiveCfg = Release|Any CPU
-		{B72D065B-862A-469B-87F1-2E521AC7CA08}.Debug|Any CPU.ActiveCfg = Debug|x86
-		{B72D065B-862A-469B-87F1-2E521AC7CA08}.Debug|Any CPU.Build.0 = Debug|x86
-		{B72D065B-862A-469B-87F1-2E521AC7CA08}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{B72D065B-862A-469B-87F1-2E521AC7CA08}.Debug|Mixed Platforms.Build.0 = Debug|x86
-		{B72D065B-862A-469B-87F1-2E521AC7CA08}.Debug|x86.ActiveCfg = Debug|x86
-		{B72D065B-862A-469B-87F1-2E521AC7CA08}.Debug|x86.Build.0 = Debug|x86
-		{B72D065B-862A-469B-87F1-2E521AC7CA08}.Release|Any CPU.ActiveCfg = Release|x86
-		{B72D065B-862A-469B-87F1-2E521AC7CA08}.Release|Mixed Platforms.ActiveCfg = Release|x86
-		{B72D065B-862A-469B-87F1-2E521AC7CA08}.Release|Mixed Platforms.Build.0 = Release|x86
-		{B72D065B-862A-469B-87F1-2E521AC7CA08}.Release|x86.ActiveCfg = Release|x86
-		{B72D065B-862A-469B-87F1-2E521AC7CA08}.Release|x86.Build.0 = Release|x86
+		{B72D065B-862A-469B-87F1-2E521AC7CA08}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B72D065B-862A-469B-87F1-2E521AC7CA08}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B72D065B-862A-469B-87F1-2E521AC7CA08}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B72D065B-862A-469B-87F1-2E521AC7CA08}.Release|Any CPU.Build.0 = Release|Any CPU
 		{CB5C2235-43B2-4B37-B866-D5D33F0E68B0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{CB5C2235-43B2-4B37-B866-D5D33F0E68B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{CB5C2235-43B2-4B37-B866-D5D33F0E68B0}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{CB5C2235-43B2-4B37-B866-D5D33F0E68B0}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{CB5C2235-43B2-4B37-B866-D5D33F0E68B0}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{CB5C2235-43B2-4B37-B866-D5D33F0E68B0}.Debug|x86.Build.0 = Debug|Any CPU
 		{CB5C2235-43B2-4B37-B866-D5D33F0E68B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CB5C2235-43B2-4B37-B866-D5D33F0E68B0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{CB5C2235-43B2-4B37-B866-D5D33F0E68B0}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{CB5C2235-43B2-4B37-B866-D5D33F0E68B0}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{CB5C2235-43B2-4B37-B866-D5D33F0E68B0}.Release|x86.ActiveCfg = Release|Any CPU
-		{CB5C2235-43B2-4B37-B866-D5D33F0E68B0}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/CSharpTranslator/src/CS2JTranslator/CS2JTranslator.csproj
+++ b/CSharpTranslator/src/CS2JTranslator/CS2JTranslator.csproj
@@ -280,6 +280,13 @@
     <Content Include="NetFramework\System\ArgumentOutOfRangeException.xml" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PreBuildEvent>java -Xmx512m -jar $(ProjectDir)..\..\jar\antlr-3.3.jar -Xconversiontimeout 15000 -make -verbose $(ProjectDir)..\CSharpParser\cs.g -o $(ProjectDir)..\CSharpParser
+java -Xmx512m -jar $(ProjectDir)..\..\jar\antlr-3.3.jar -Xconversiontimeout 15000 -make -verbose -lib $(ProjectDir)..\CSharpParser $(ProjectDir)CS2JTransform\TemplateExtracter.g -o $(ProjectDir)CS2JTransform
+java -Xmx512m -jar $(ProjectDir)..\..\jar\antlr-3.3.jar -Xconversiontimeout 15000 -make -verbose -lib $(ProjectDir)..\CSharpParser $(ProjectDir)CS2JTransform\JavaMaker.g -o $(ProjectDir)CS2JTransform
+java -Xmx512m -jar $(ProjectDir)..\..\jar\antlr-3.3.jar -Xconversiontimeout 15000 -make -verbose -lib $(ProjectDir)..\CSharpParser $(ProjectDir)CS2JTransform\NetMaker.g -o $(ProjectDir)CS2JTransform
+java -Xmx512m -jar $(ProjectDir)..\..\jar\antlr-3.3.jar -Xconversiontimeout 15000 -make -verbose -lib $(ProjectDir)..\CSharpParser $(ProjectDir)CS2JTransform\JavaPrettyPrint.g -o $(ProjectDir)CS2JTransform</PreBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/CSharpTranslator/src/CS2JTranslator/CS2JTranslator.csproj
+++ b/CSharpTranslator/src/CS2JTranslator/CS2JTranslator.csproj
@@ -10,8 +10,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CS2JTranslator</RootNamespace>
     <AssemblyName>cs2j</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject>Twiglet.CS2J.Translator.Driver</StartupObject>
@@ -67,6 +68,7 @@
     <None Include="..\CSharpParser\cs.g">
       <Link>CSharpParser\cs.g</Link>
     </None>
+    <None Include="app.config" />
     <None Include="CS2JTransform\JavaMaker.g" />
     <None Include="CS2JTransform\JavaPrettyPrint.g" />
     <None Include="CS2JTransform\NetMaker.g" />

--- a/CSharpTranslator/src/CS2JTranslator/CS2JTranslator.csproj
+++ b/CSharpTranslator/src/CS2JTranslator/CS2JTranslator.csproj
@@ -13,28 +13,26 @@
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
-    <PlatformTarget>x86</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Commandlineparameters>-config /Users/keving/tmp/secs2j.ini</Commandlineparameters>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
-    <PlatformTarget>x86</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
   <PropertyGroup>
     <StartupObject>Twiglet.CS2J.Translator.Driver</StartupObject>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\CSharpParser\AntlrUtils.cs">

--- a/CSharpTranslator/src/CS2JTranslator/app.config
+++ b/CSharpTranslator/src/CS2JTranslator/app.config
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>

--- a/CSharpTranslator/src/NDesk.Options/NDesk.Options.csproj
+++ b/CSharpTranslator/src/NDesk.Options/NDesk.Options.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,7 +9,8 @@
     <OutputType>Library</OutputType>
     <RootNamespace>NDesk.Options</RootNamespace>
     <AssemblyName>NDesk.Options</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/CSharpTranslator/src/Nini/Nini.csproj
+++ b/CSharpTranslator/src/Nini/Nini.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,7 +9,8 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Nini</RootNamespace>
     <AssemblyName>Nini</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
E.g. from VS. With Java 8 need to attempt to build twice (grammars are generated despite the error in Antlr)
